### PR TITLE
Log when a system font cannot be found

### DIFF
--- a/Furball.Engine/Engine/Graphics/ContentManager.cs
+++ b/Furball.Engine/Engine/Graphics/ContentManager.cs
@@ -51,7 +51,8 @@ public static class ContentManager {
             return sys;
 
         //If we cant find the font, just give them the default one, ittl work
-        if (!SystemFonts.TryGet(familyName, out FontFamily font)) {
+        if (!SystemFonts.TryGet(familyName, out FontFamily font))
+        {
             Logger.Log($"Could not load system font by family name \"{familyName}\", loading default font instead", LoggerLevelEngineInfo.Instance);
             return FurballGame.DefaultFont;
         }

--- a/Furball.Engine/Engine/Graphics/ContentManager.cs
+++ b/Furball.Engine/Engine/Graphics/ContentManager.cs
@@ -51,8 +51,10 @@ public static class ContentManager {
             return sys;
 
         //If we cant find the font, just give them the default one, ittl work
-        if (!SystemFonts.TryGet(familyName, out FontFamily font))
+        if (!SystemFonts.TryGet(familyName, out FontFamily font)) {
+            Logger.Log($"Could not load system font by family name \"{familyName}\", loading default font instead", LoggerLevelEngineInfo.Instance);
             return FurballGame.DefaultFont;
+        }
 
         Font regularFont = font.CreateFont(30, style);
 


### PR DESCRIPTION
I was attempting to load a system font that did not exist and was confused as to why I did not see the font; this should help make that case more clear to developers.

Example output:
```
EngineInfo: Could not load system font by family name "Comic Sans", loading default font instead
```
